### PR TITLE
appdata: Add hardware support metadata

### DIFF
--- a/org.tuxpaint.Tuxpaint.appdata.xml
+++ b/org.tuxpaint.Tuxpaint.appdata.xml
@@ -91,4 +91,13 @@ SentUpstream: 2014-09-18
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <update_contact>tuxpaint-devel@lists.sourceforge.net</update_contact>
+  <recommends>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+    <display_length compare="ge">medium</display_length>
+  </recommends>
+  <requires>
+    <display_length compare="ge">small</display_length>
+  </requires>
 </application>


### PR DESCRIPTION
This data will be consumed by GNOME Software 41. See
https://tecnocode.co.uk/2021/07/12/add-metadata-to-your-app-to-say-what-inputs-and-display-sizes-it-supports/.

This app is usable with only a touchscreen – this is how my in-house
tester uses it. (Text entry needs a keyboard, so a keyboard is
recommended, but not strictly required.)

http://www.tuxpaint.org/requirements/ says:

> Monitor: 640x480 or higher; 800x600 recommended

I'm going to round this to "small required, medium recommended".
