### PR TITLE
Improve appdata

### DIFF
--- a/org.tuxpaint.Tuxpaint.appdata.xml
+++ b/org.tuxpaint.Tuxpaint.appdata.xml
@@ -24,7 +24,14 @@ SentUpstream: 2014-09-18
       help them be creative.
     </p>
   </description>
+  <developer_name>New Breed Software et al.</developer_name>
   <url type="homepage">http://tuxpaint.org/</url>
+  <url type="bugtracker">https://sourceforge.net/p/tuxpaint/_list/tickets</url>
+  <url type="faq">http://www.tuxpaint.org/docs/en/html/FAQ.html</url>
+  <url type="help">http://www.tuxpaint.org/docs/</url>
+  <url type="donation">http://www.newbreedsoftware.com/donate/</url>
+  <url type="translate">http://www.tuxpaint.org/help/po/</url>
+  <url type="contact">http://www.tuxpaint.org/contact/</url>
   <screenshots>
     <screenshot type="default">http://tuxpaint.org/screenshots/starter-coloringbook.png</screenshot>
     <screenshot>http://tuxpaint.org/screenshots/example_simple.png</screenshot>
@@ -100,4 +107,5 @@ SentUpstream: 2014-09-18
   <requires>
     <display_length compare="ge">small</display_length>
   </requires>
+  <translation type="gettext">tuxpaint</translation>
 </application>


### PR DESCRIPTION
Improve appdata

The developer name and the URLs will be shown more prominently in GNOME
Software 41.

By adding `<translation>`, the flathub appstream will include information
about which languages Tux Paint is translated into. This is displayed in
GNOME Software and other frontends.
