### PR TITLE
fedc: Only update when main app or stamps update

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "require-important-update": true
+}

--- a/org.tuxpaint.Tuxpaint.json
+++ b/org.tuxpaint.Tuxpaint.json
@@ -89,7 +89,7 @@
             "make-install-args": [
                 "LDFLAGS=-L/app/lib",
                 "PREFIX=/app",
-                "ARCH_INSTALL=install-man install-importscript"
+                "PACKAGE_ONLY=yes"
             ],
             "sources": [
                 {
@@ -116,10 +116,8 @@
             ],
             "post-install": [
                 "install -m644 -Dt /app/share/icons/hicolor/scalable/apps data/images/tuxpaint-icon.svg",
-                "for size in 192 128 96 64 48 32 22 16; do install -m644 -D data/images/icon${size}x${size}.png /app/share/icons/hicolor/${size}x${size}/apps/tuxpaint.png; done",
-                "desktop-file-edit --set-key=Keywords --set-value=tuxpaint src/tuxpaint.desktop",
-                "install -m644 -Dt /app/share/applications src/tuxpaint.desktop",
-                "install -m644 -Dt /app/share/metainfo src/org.tuxpaint.Tuxpaint.appdata.xml",
+                "rm /app/share/applications/tuxpaint-fullscreen.desktop",
+                "desktop-file-edit --set-key=Keywords --set-value=tuxpaint /app/share/applications/tuxpaint.desktop",
                 "install -m644 -Dt /app/etc/tuxpaint tuxpaint.conf"
             ]
         },

--- a/org.tuxpaint.Tuxpaint.json
+++ b/org.tuxpaint.Tuxpaint.json
@@ -94,6 +94,7 @@
             "sources": [
                 {
                     "x-checker-data": {
+                        "is-main-source": true,
                         "type": "html",
                         "url": "https://sourceforge.net/projects/tuxpaint/rss?path=/tuxpaint",
                         "pattern": "(https://sourceforge.net/projects/tuxpaint/files/tuxpaint/(\\d+\\.\\d+\\.\\d+)/tuxpaint-\\2.tar.gz)"
@@ -128,6 +129,7 @@
             "sources": [
                 {
                     "x-checker-data": {
+                        "is-important": true,
                         "type": "html",
                         "url": "https://sourceforge.net/projects/tuxpaint/rss?path=/tuxpaint-stamps",
                         "pattern": "(https://sourceforge.net/projects/tuxpaint/files/tuxpaint-stamps/\\d{4}-\\d{2}-\\d{2}/tuxpaint-stamps-(\\d{4}\\.\\d{2}\\.\\d{2})\\.tar\\.gz)"


### PR DESCRIPTION
ImageMagick releases very frequently but is only used at build time so
it is uninteresting to have flatpak-external-data-checker trigger merge
requests for it.
