### PR TITLE
Updates for Appstream 1.0 compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.json]
+indent_style = space
+indent_size = 4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/Remove-trailing-period-from-translations-of-Tux-Pain.patch
+++ b/Remove-trailing-period-from-translations-of-Tux-Pain.patch
@@ -1,0 +1,44 @@
+From eac10ed522394f050193b3a5f59d149664fd2a97 Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Sat, 17 Feb 2024 23:00:02 +0000
+Subject: [PATCH] Remove trailing period from translations of "Tux Paint"
+
+appstreamcli validate gets very upset if you have a trailing period in
+the name of the app:
+
+    E: org.tuxpaint.Tuxpaint:116: name-has-dot-suffix P\u025bntiri Tukisi .
+    E: org.tuxpaint.Tuxpaint:119: name-has-dot-suffix Tuks il\u0259 \u015f\u0259kil \u00e7\u0259k.
+---
+ src/po/az.po | 2 +-
+ src/po/bm.po | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/po/az.po b/src/po/az.po
+index 488ea366..42238f88 100644
+--- a/src/po/az.po
++++ b/src/po/az.po
+@@ -335,7 +335,7 @@ msgstr ""
+ 
+ #: ../org.tuxpaint.Tuxpaint.appdata.xml.in:9 ../tuxpaint.desktop.in:3
+ msgid "Tux Paint"
+-msgstr "Tuks ilə şəkil çək."
++msgstr "Tuks ilə şəkil çək"
+ 
+ #: ../org.tuxpaint.Tuxpaint.appdata.xml.in:10 ../tuxpaint.desktop.in:10
+ #: ../tuxpaint-fullscreen.desktop.in:10
+diff --git a/src/po/bm.po b/src/po/bm.po
+index 42441cff..c29fc76a 100644
+--- a/src/po/bm.po
++++ b/src/po/bm.po
+@@ -337,7 +337,7 @@ msgstr ""
+ 
+ #: ../org.tuxpaint.Tuxpaint.appdata.xml.in:9 ../tuxpaint.desktop.in:3
+ msgid "Tux Paint"
+-msgstr "Pɛntiri Tukisi ."
++msgstr "Pɛntiri Tukisi"
+ 
+ #: ../org.tuxpaint.Tuxpaint.appdata.xml.in:10 ../tuxpaint.desktop.in:10
+ #: ../tuxpaint-fullscreen.desktop.in:10
+-- 
+2.43.0
+

--- a/appdata-Add-new-developer-tag.patch
+++ b/appdata-Add-new-developer-tag.patch
@@ -1,0 +1,31 @@
+From 91a0b75ae6a840ea8b6c9a629d118a9c992c383c Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Sat, 17 Feb 2024 20:15:27 +0000
+Subject: [PATCH 3/3] appdata: Add new <developer> tag
+
+Appstream 1.0 introduces a new <developer> tag which supersedes
+<developer_name>. Add it, keeping <developer_name> for
+backwards-compatibility.
+
+https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer
+---
+ src/org.tuxpaint.Tuxpaint.appdata.xml.in | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/org.tuxpaint.Tuxpaint.appdata.xml.in b/src/org.tuxpaint.Tuxpaint.appdata.xml.in
+index 799c1a16..9a46b23c 100644
+--- a/src/org.tuxpaint.Tuxpaint.appdata.xml.in
++++ b/src/org.tuxpaint.Tuxpaint.appdata.xml.in
+@@ -23,6 +23,9 @@
+     </p>
+   </description>
+   <developer_name>Bill Kendrick, et al.</developer_name>
++  <developer id="newbreedsoftware.com">
++    <name>Bill Kendrick, et al.</name>
++  </developer>
+   <url type="homepage">https://tuxpaint.org/</url>
+   <url type="bugtracker">https://sourceforge.net/p/tuxpaint/_list/tickets</url>
+   <url type="faq">https://tuxpaint.org/docs/en/html/FAQ.html</url>
+-- 
+2.43.0
+

--- a/appdata-Indicate-that-Tuxpaint-is-fully-offline.patch
+++ b/appdata-Indicate-that-Tuxpaint-is-fully-offline.patch
@@ -1,0 +1,25 @@
+From 259442d65f1fe14e3fd66d5f6a5a735403558a4a Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Sat, 17 Feb 2024 20:14:09 +0000
+Subject: [PATCH 2/3] appdata: Indicate that Tuxpaint is fully offline
+
+https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-internet
+---
+ src/org.tuxpaint.Tuxpaint.appdata.xml.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/org.tuxpaint.Tuxpaint.appdata.xml.in b/src/org.tuxpaint.Tuxpaint.appdata.xml.in
+index c1f73175..799c1a16 100644
+--- a/src/org.tuxpaint.Tuxpaint.appdata.xml.in
++++ b/src/org.tuxpaint.Tuxpaint.appdata.xml.in
+@@ -173,6 +173,7 @@
+   <requires>
+     <display_length compare="ge">500</display_length>
+     <display_length compare="le">32000</display_length>
++    <internet>offline-only</internet>
+   </requires>
+   <translation type="gettext">tuxpaint</translation>
+   <launchable type="desktop-id">tuxpaint.desktop</launchable>
+-- 
+2.43.0
+

--- a/appdata-Replace-named-display_length-with-constant-v.patch
+++ b/appdata-Replace-named-display_length-with-constant-v.patch
@@ -1,0 +1,46 @@
+From dd6f7b3336df839a8818e16a1173bc67912e519f Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Sat, 17 Feb 2024 18:16:08 +0000
+Subject: [PATCH 1/3] appdata: Replace named display_length with constant
+ values
+
+The named values for <display_length> were removed in Appstream 1.0,
+released recently.  In their place, use integer values.
+
+For the <requires> block, attempt to encode the same reasonableness
+restrictions as are enforced on the windowsize setting. The code
+requires the height to be at least 480px and the width at least 500px,
+but there is no way to specify width versus height, just shortest versus
+longest edge, so I just require that the shortest edge is at least
+500px.
+
+For the <recommends> block, 768px is the suggested number in the
+appstream specification for laptops and tablets.
+
+https://github.com/ximion/appstream/commit/005c5f104d45953cd25f842b70dcd3d32466333b
+https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-display_length
+---
+ src/org.tuxpaint.Tuxpaint.appdata.xml.in | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/org.tuxpaint.Tuxpaint.appdata.xml.in b/src/org.tuxpaint.Tuxpaint.appdata.xml.in
+index 6d27a9ab..c1f73175 100644
+--- a/src/org.tuxpaint.Tuxpaint.appdata.xml.in
++++ b/src/org.tuxpaint.Tuxpaint.appdata.xml.in
+@@ -168,10 +168,11 @@
+     <control>keyboard</control>
+     <control>pointing</control>
+     <control>touch</control>
+-    <display_length compare="ge">medium</display_length>
++    <display_length compare="ge">768</display_length>
+   </recommends>
+   <requires>
+-    <display_length compare="ge">small</display_length>
++    <display_length compare="ge">500</display_length>
++    <display_length compare="le">32000</display_length>
+   </requires>
+   <translation type="gettext">tuxpaint</translation>
+   <launchable type="desktop-id">tuxpaint.desktop</launchable>
+-- 
+2.43.0
+

--- a/org.tuxpaint.Tuxpaint.json
+++ b/org.tuxpaint.Tuxpaint.json
@@ -109,7 +109,8 @@
                         "Makefile-sdl2_gfx-pkgconfig.patch",
                         "appdata-Replace-named-display_length-with-constant-v.patch",
                         "appdata-Indicate-that-Tuxpaint-is-fully-offline.patch",
-                        "appdata-Add-new-developer-tag.patch"
+                        "appdata-Add-new-developer-tag.patch",
+                        "Remove-trailing-period-from-translations-of-Tux-Pain.patch"
 
                     ]
                 },

--- a/org.tuxpaint.Tuxpaint.json
+++ b/org.tuxpaint.Tuxpaint.json
@@ -106,7 +106,11 @@
                 {
                     "type": "patch",
                     "paths": [
-                        "Makefile-sdl2_gfx-pkgconfig.patch"
+                        "Makefile-sdl2_gfx-pkgconfig.patch",
+                        "appdata-Replace-named-display_length-with-constant-v.patch",
+                        "appdata-Indicate-that-Tuxpaint-is-fully-offline.patch",
+                        "appdata-Add-new-developer-tag.patch"
+
                     ]
                 },
                 {


### PR DESCRIPTION
Appstream 1.0 removed symbolic screen sizes like `small`.