### PR TITLE
Remove --socket=x11

### DIFF
--- a/org.tuxpaint.Tuxpaint.json
+++ b/org.tuxpaint.Tuxpaint.json
@@ -7,7 +7,6 @@
         "--device=dri",
         "--filesystem=xdg-pictures/TuxPaint:create",
         "--share=ipc",
-        "--socket=x11",
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",


### PR DESCRIPTION
As a backwards-compatibility mechanism for Flatpak versions that predate
--socket=fallback-x11, --socket=x11 is ignored if --socket=fallback-x11
is used.

However Flatpak 0.11.3 which introduced fallback-x11 is now 6 years old;
Flathub's stats suggest that nobody is using any older version; and the
Flathub linter will start rejecting this backwards-compatibility
pattern.

Remove the harmless but effectively useless --socket=x11 flag.

Fixes https://github.com/flathub/org.tuxpaint.Tuxpaint/issues/56
